### PR TITLE
Add `HexPrefixed` type

### DIFF
--- a/src/hex-prefixed.d.ts
+++ b/src/hex-prefixed.d.ts
@@ -1,0 +1,8 @@
+/**
+ * A string prefixed with "0x". This usually indicates that the string is a
+ * hexadecimal number.
+ *
+ * Note that this type doesn't ensure the string is a valid hexadecimal value.
+ * It only matches the "0x" prefix.
+ */
+export type HexPrefixed = `0x${string}`;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,2 @@
 export * from './json';
+export * from './hex-prefixed';

--- a/test-d/hex-prefixed.test-d.ts
+++ b/test-d/hex-prefixed.test-d.ts
@@ -1,0 +1,26 @@
+import { expectAssignable, expectNotAssignable } from 'tsd';
+
+import { HexPrefixed } from '../src/hex-prefixed';
+
+// Valid hex-prefixed strings:
+
+expectAssignable<HexPrefixed>('0x');
+
+expectAssignable<HexPrefixed>('0x0');
+
+expectAssignable<HexPrefixed>('0x😀');
+
+const embeddedString = 'test';
+expectAssignable<HexPrefixed>(`0x${embeddedString}`);
+
+// Not valid hex-prefixed strings:
+
+expectNotAssignable<HexPrefixed>(`0X${embeddedString}`);
+
+expectNotAssignable<HexPrefixed>(`1x${embeddedString}`);
+
+expectNotAssignable<HexPrefixed>(0);
+
+expectNotAssignable<HexPrefixed>('0');
+
+expectNotAssignable<HexPrefixed>('🙃');


### PR DESCRIPTION
This type represents a string that is prefixed with `0x`. It just verifies the prefix - it doesn't guarantee anything about the contents of the string after the prefix.

This is useful for Ethereum addresses, or any data that we expect to be represented by a prefixed hex string.

I considered adding type checking to verify that the rest of the string was valid hex, but currently this is not easy to do with TypeScript. The only method I know of us to build up the conditional logic and apply it to each character one-by-one, which is fairly slow. We can pursue this in a later PR if we decide it's worth the cost.