### PR TITLE
Set version to "0.0.0" in preparation for first release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/types",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "A collection of TypeScrupt types that are used in MetaMask projects",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our release automation scripts handle the version bump step, so they expect that it hasn't been updated yet. This repository hasn't been released yet, but it has "1.0.0" as the version. Unfortunately this prevents us from creating any versions below or equal to "v1.0.0".

Setting the version to "0.0.0" fixes this. Now we can make the initial release version be anything above "v0.0.0".