### PR TITLE
Bring json-rpc-engine types up to date

### DIFF
--- a/src/json-rpc.d.ts
+++ b/src/json-rpc.d.ts
@@ -49,10 +49,13 @@ export interface JsonRpcFailure extends JsonRpcResponseBase {
 
 export type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcFailure;
 
-export interface PendingJsonRpcResponse<T> extends JsonRpcResponseBase {
-  result?: T;
-  error?: Error | JsonRpcError;
-}
+export type PendingJsonRpcResponse<Result> = Omit<
+  JsonRpcResponse<Result>,
+  'error' | 'result'
+> & {
+  result?: Result;
+  error?: JsonRpcError;
+};
 
 export type JsonRpcEngineCallbackError = Error | JsonRpcError | null;
 
@@ -68,9 +71,12 @@ export type JsonRpcEngineEndCallback = (
   error?: JsonRpcEngineCallbackError,
 ) => void;
 
-export type JsonRpcMiddleware<T, U> = (
-  req: JsonRpcRequest<T>,
-  res: PendingJsonRpcResponse<U>,
-  next: JsonRpcEngineNextCallback,
-  end: JsonRpcEngineEndCallback,
-) => void;
+export interface JsonRpcMiddleware<Params, Result> {
+  (
+    req: JsonRpcRequest<Params>,
+    res: PendingJsonRpcResponse<Result>,
+    next: JsonRpcEngineNextCallback,
+    end: JsonRpcEngineEndCallback,
+  ): void;
+  destroy?: () => void | Promise<void>;
+}


### PR DESCRIPTION
A while back, a selection of types from `json-rpc-engine` were copied to this repo. We'd like to remove those types from `json-rpc-engine` as a result, however, since then, the types in `json-rpc-engine` have received updates that are not reflected here. This commit copies the new changes over.